### PR TITLE
feat(java-example): Use host OS environment variables

### DIFF
--- a/Java/Dockerfile
+++ b/Java/Dockerfile
@@ -26,5 +26,17 @@ WORKDIR /app
 COPY --from=build /app/target/classes ./classes
 COPY --from=build /app/target/dependency ./dependency
 
+# Set ARGs for --build-arg options passed in the build command
+ARG DATABASE_FIELD
+ARG DATABASE_NAME
+ARG HOST
+ARG TOKEN
+
+# Set run-time ENVs from ARGs
+ENV DATABASE_FIELD=${DATABASE_FIELD}
+ENV DATABASE_NAME=${DATABASE_NAME}
+ENV HOST=${HOST}
+ENV TOKEN=${TOKEN}
+
 # Set the entrypoint to run your Java application
 ENTRYPOINT ["java", "-cp", "classes:dependency/*", "com.example.javaexample.JavaExample"]

--- a/Java/README.md
+++ b/Java/README.md
@@ -23,8 +23,11 @@ SQL queries, and retrieve data.
 
 Running the application requires the following:
 
-- **Docker**: Follow the [Docker install](https://docs.docker.com/desktop/install/) instructions for your system.
-              The Java example project uses Docker to simplify dependency management.
+- **Docker**: The example project uses Docker to ensure a consistent build environment. Follow the instructions to download and install Docker for your system:
+
+    - **macOS**: [Install Docker for macOS](https://docs.docker.com/desktop/install/mac-install/)
+    - **Linux**: [Install Docker for Linux](https://docs.docker.com/desktop/install/linux-install/)
+              
 - **Database**: The name of a Flight database to query--for example, an [InfluxDB Cloud Serverless bucket](https://docs.influxdata.com/influxdb/cloud-serverless/admin/buckets/).
 - **Host**: The hostname of the Flight server--for example, your [InfluxDB Cloud Serverless region](https://docs.influxdata.com/influxdb/cloud-serverless/reference/regions/) without the protocol("https://").
 - **Token**: An authentication `Bearer` token with _read_ permission to the database--for example, an [InfluxDB Cloud Serverless API token](https://docs.influxdata.com/influxdb/cloud-serverless/get-started/setup/).

--- a/Java/README.md
+++ b/Java/README.md
@@ -1,3 +1,60 @@
 # Java_FlightSqlClient
-Example of how to query InfluxDB IOx with the Java FlightSqlClient
-Please provide yoru bucket, token, 
+
+The Java example is a standalone Java application for querying
+Apache Arrow Flight database servers like InfluxDB v3 using RPC and Flight SQL.
+
+## Description
+
+The example shows how to create a Java application that uses
+Apache Arrow Flight (`org.apache.arrow.flight`)
+and Flight SQL (`org.apache.arrow.flight.sql`) packages to 
+interact with a Flight database server.
+
+You can use the example to connect to InfluxDB v3, execute database commands and
+SQL queries, and retrieve data.
+
+## Build and run the Java application
+
+1. [Prerequisites](#prerequisites)
+2. [Build](#build)
+3. [Run](#run)
+
+### Prerequisites
+
+Running the application requires the following:
+
+- **Docker**: Follow the [Docker install](https://docs.docker.com/desktop/install/) instructions for your system.
+              The Java example project uses Docker to simplify dependency management.
+- **Database**: The name of a Flight database to query--for example, an [InfluxDB Cloud Serverless bucket](https://docs.influxdata.com/influxdb/cloud-serverless/admin/buckets/).
+- **Host**: The hostname of the Flight server--for example, your [InfluxDB Cloud Serverless region](https://docs.influxdata.com/influxdb/cloud-serverless/reference/regions/) without the protocol("https://").
+- **Token**: An authentication `Bearer` token with _read_ permission to the database--for example, an [InfluxDB Cloud Serverless API token](https://docs.influxdata.com/influxdb/cloud-serverless/get-started/setup/).
+
+### Build
+
+The project contains an `influxdb-build.sh` script that you can use with InfluxDB v3 or as an example to create your build script.
+
+#### Example: Build for InfluxDB Cloud
+
+1. In your terminal, set the following environment variables.
+
+    ```sh
+    # Set environment variables
+
+    export INFLUX_DATABASE=my-v3-bucket && \
+    export INFLUX_HOST=us-east-1-1.aws.cloud2.influxdata.com && \
+    export INFLUX_TOKEN=WIIiwererffkdfoiwe==
+    ```
+
+2. Run one of the following:
+    - For Cloud Serverless: `sh ./influxdb-build.sh serverless`
+    - For Cloud Dedicated: `sh ./influxdb-build.sh dedicated`
+
+The script builds an image with the name `javaflight`.
+
+### Run
+
+To start the application, run `docker run <IMAGE_NAME>` in your terminal.
+
+```sh
+docker run javaflight
+```

--- a/Java/influxdb-build.sh
+++ b/Java/influxdb-build.sh
@@ -1,0 +1,24 @@
+# Cloud Serverless build
+function serverless() {
+  _build bucket-name
+}
+
+# Cloud Dedicated build
+function dedicated() {
+  _build iox-namespace-name
+}
+
+function _build() {
+  docker build \
+    --build-arg DATABASE_FIELD=$1 \
+    --build-arg DATABASE_NAME=$INFLUX_DATABASE \
+    --build-arg HOST=$INFLUX_HOST \
+    --build-arg TOKEN=$INFLUX_TOKEN \
+    -t javaflight .
+}
+
+if [ -z $1 ]; then
+    serverless
+else
+    $1
+fi

--- a/Java/src/main/java/JavaExample.java
+++ b/Java/src/main/java/JavaExample.java
@@ -12,14 +12,20 @@ import io.grpc.Metadata;
 import java.net.URI;
 
 public class JavaExample {
+
+    /* Get environment variables */
+    public static final String DATABASE_FIELD = System.getenv("DATABASE_FIELD");
+    public static final String DATABASE_NAME = System.getenv("DATABASE_NAME");
+    public static final String HOST = System.getenv("HOST");
+    public static final String TOKEN = System.getenv("TOKEN");
+            
     public static void main(String[] args) {
         System.out.println("Query InfluxDB with the Java Flight SQL Client");
-        String host = "<host without https:// i.e. us-east-1-1.aws.cloud2.influxdata.com>";
         
-        String query = "SELECT *";
-        Location location = Location.forGrpcTls(host, 443);
+        String query = "SELECT * FROM home";
+        Location location = Location.forGrpcTls(HOST, 443);
 
-        CredentialCallOption auth = new CredentialCallOption(new BearerCredentialWriter("<your token>"));
+        CredentialCallOption auth = new CredentialCallOption(new BearerCredentialWriter(TOKEN));
         BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
 
         // We're creating an interceptor here to inject the database header on every
@@ -27,7 +33,7 @@ public class JavaExample {
         FlightClientMiddleware.Factory f = info -> new FlightClientMiddleware() {
             @Override
             public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-                outgoingHeaders.insert("database", "<your bucket>");
+                outgoingHeaders.insert(DATABASE_FIELD, DATABASE_NAME);
             }
 
             @Override


### PR DESCRIPTION
- Add instructions to README.
- Add ARG names to set from --build-arg flags.
- Set ENV variables to use in the run-time.
- Add influxdb-build.sh that uses typical INFLUX_ environment variable names ~~and sets the correct DATABASE metadata key for Cloud Serverless or Cloud Dedicated~~.